### PR TITLE
Autodetect Whip-compatible inverted elevation rotor

### DIFF
--- a/WCTurretScript/Script.cs
+++ b/WCTurretScript/Script.cs
@@ -322,6 +322,8 @@ namespace WCTurretScript
                 if(Elevations.Count == 0)
                     return; 
                 MainElevation = Elevations[0];
+                if (MainElevation.CustomName.Contains("#LEFT#"))
+                    invertRot = true;
                 foreach (IMyMotorStator e in Elevations){
                     getElevationBlocks(blocks, e);
                 }


### PR DESCRIPTION
An elevation rotor with #LEFT# in its name will default to inverted.